### PR TITLE
Fix reading lines containing only spaces

### DIFF
--- a/rwx.cc
+++ b/rwx.cc
@@ -364,7 +364,7 @@ bool bfc_ram::is_ignorable_line(const string& line)
 		if (line.substr(8, 2) == ": " && line.substr(48, 2) == " |") {
 			m_hint_decimal = false;
 			return false;
-		} else if (contains(line, ": ") && contains(line, " | ")) {
+		} else if (contains(line, ": ") && (contains(line, " | ") || ends_with(line, " |"))) {
 			// if another message is printed by the firmware, the dump
 			// output sometimes switches to an all-decimal format.
 			m_hint_decimal = true;


### PR DESCRIPTION
This commit fixes a false positive when parsing the second line of this block:
```
2169534304: 538977584  946632736  00000000  170226464 |   %08lx .....%s
2169534320: 538976288  538976288  538976288  538976288 |
2169534336: 536870912  628303219  541149216  538977584 |  ...%s%s AH   %0
```

EDIT: I guess I could've changed the original needle, but I'm playing it safe.