### PR TITLE
Tc7210

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,13 @@ Partially supported:
 * Motorola MG7550
 * Motorola MB7420
 * Sagemcom F@ST 3686 AC
+* Technicolor TC7210
 
 Devices _not_ listed above may still be supported, but with less features! It should be easy to add support for other devices. Some pointers can be found [below](#writing-a-device-profile).
 
 Binaries for macOS and Windows are available [here](https://github.com/jclehner/bcm2-utils/releases).
+
+For Arch-based Linux distros, there's [a package](https://aur.archlinux.org/packages/bcm2-utils-git) on the Arch User Repository. 
 
 ## bcm2dump
 ```

--- a/profiledef.c
+++ b/profiledef.c
@@ -1133,6 +1133,90 @@ struct bcm2_profile bcm2_profiles[] = {
 			},
 		}
 	},
+	{
+		.name = "tc7210",
+		.pretty = "Technicolor TC7210",
+		.arch = BCM2_3384,
+		.baudrate = 115200,
+		.kseg1mask = 0x20000000,
+		.cfg_flags = BCM2_CFG_ENC_AES256_ECB | BCM2_CFG_PAD_ZEROBLK |
+			BCM2_CFG_FMT_GWS_PAD_OPTIONAL,
+#if 0
+		.cfg_md5key = "544d4d5f544337323030000000000000",
+#endif
+		.cfg_keyfun = &keyfun_tc7200,
+		.cfg_defkeys = {
+			"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+			"0001020304050607080910111213141516171819202122232425262728293031"
+		},
+		.magic = {
+			{ 0x80000818, "2.5.0beta1" }			
+		},
+		.spaces = {
+			{
+				.name = "ram",
+				.min = 0x80000000,
+				.size = 256 * 1024 * 1024,
+#if 0
+				.parts = {
+					{ "bootloader", 0x80000000, 0x010000 },
+					{ "image",   0x85f00000, 0x6c0000 },
+					{ "linux",      0x87000000, 0x480000 }
+				}
+#endif
+			},
+			{
+				.name = "nvram",
+				.size = 0x100000,
+				.parts = {
+					{ "bootloader", 0x00000, 0x10000 },
+					{ "permnv",     0x10000, 0x20000, "perm" },
+					{ "unknown",    0x30000, 0x90000 },
+					{ "dynnv",      0xc0000, 0x40000, "dyn" }
+				},
+			},
+			{
+				.name = "flash",
+				.size = 128 * 1024 * 1024,
+				.parts = {
+					{ "linuxapps", 0x0000000, 0x2c00000, "image3e" },
+					{ "image1",    0x2c00000, 0x1000000 },
+					{ "image2",    0x3c00000, 0x1000000 },
+					{ "linux",     0x4c00000, 0x0800000, "image3" },
+					{ "linuxkfs",  0x5400000, 0x2000000, "" },
+					{ "dhtml",     0x7400000, 0x0c00000 },
+				},
+			},
+		},
+		.versions = { 
+			{
+				.intf = BCM2_INTF_BFC,
+				.options = {
+					BCM2_VAL_U32("bfc:conthread_priv_off", 0x74),
+					BCM2_VAL_STR("bfc:su_password", "brcm"),
+					BCM2_VAL_U32("bfc:flash_reinit_on_retry", true),
+					BCM2_VAL_U32("bfc:flash_read_direct", true),
+					BCM2_VAL_U32("bfc:flash_readsize", 8192),
+				},
+			},
+#if 0
+			{
+				.version = "2.5.0beta1",
+				.intf = BCM2_INTF_BFC,
+				.magic = { 0x80000818, "2.5.0beta1" },
+				.spaces = {
+						{
+							.name = "flash",
+							.open = { 0x803f72e4, BCM2_ARGS_OE },
+							.read = { 0x803f6d90, BCM2_READ_FUNC_BOL,
+									.patch = {{ 0x803f6f3c, 0x10000018 }},
+							}
+						},
+				}
+			},
+#endif			
+		},
+	},
 	// end marker
 	{ .name = "" },
 };

--- a/profiledef.c
+++ b/profiledef.c
@@ -1141,8 +1141,8 @@ struct bcm2_profile bcm2_profiles[] = {
 		.kseg1mask = 0x20000000,
 		.cfg_flags = BCM2_CFG_ENC_AES256_ECB | BCM2_CFG_PAD_ZEROBLK |
 			BCM2_CFG_FMT_GWS_PAD_OPTIONAL,
-#if 0
-		.cfg_md5key = "544d4d5f544337323030000000000000",
+#if 1
+		.cfg_md5key = "544d4d5f544337323130000000000000",
 #endif
 		.cfg_keyfun = &keyfun_tc7200,
 		.cfg_defkeys = {
@@ -1192,11 +1192,11 @@ struct bcm2_profile bcm2_profiles[] = {
 			{
 				.intf = BCM2_INTF_BFC,
 				.options = {
-					BCM2_VAL_U32("bfc:conthread_priv_off", 0x74),
+//					BCM2_VAL_U32("bfc:conthread_priv_off", 0x74),
 					BCM2_VAL_STR("bfc:su_password", "brcm"),
 					BCM2_VAL_U32("bfc:flash_reinit_on_retry", true),
 					BCM2_VAL_U32("bfc:flash_read_direct", true),
-					BCM2_VAL_U32("bfc:flash_readsize", 8192),
+					BCM2_VAL_U32("bfc:flash_readsize", 2048),
 				},
 			},
 #if 0

--- a/profiledef.c
+++ b/profiledef.c
@@ -1141,9 +1141,7 @@ struct bcm2_profile bcm2_profiles[] = {
 		.kseg1mask = 0x20000000,
 		.cfg_flags = BCM2_CFG_ENC_AES256_ECB | BCM2_CFG_PAD_ZEROBLK |
 			BCM2_CFG_FMT_GWS_PAD_OPTIONAL,
-#if 1
 		.cfg_md5key = "544d4d5f544337323130000000000000",
-#endif
 		.cfg_keyfun = &keyfun_tc7200,
 		.cfg_defkeys = {
 			"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
@@ -1192,7 +1190,9 @@ struct bcm2_profile bcm2_profiles[] = {
 			{
 				.intf = BCM2_INTF_BFC,
 				.options = {
-//					BCM2_VAL_U32("bfc:conthread_priv_off", 0x74),
+#if 0
+					BCM2_VAL_U32("bfc:conthread_priv_off", 0x74),
+#endif
 					BCM2_VAL_STR("bfc:su_password", "brcm"),
 					BCM2_VAL_U32("bfc:flash_reinit_on_retry", true),
 					BCM2_VAL_U32("bfc:flash_read_direct", true),

--- a/profiledef.c
+++ b/profiledef.c
@@ -1136,6 +1136,7 @@ struct bcm2_profile bcm2_profiles[] = {
 	{
 		.name = "tc7210",
 		.pretty = "Technicolor TC7210",
+		.pssig = 0xa82c,
 		.arch = BCM2_3384,
 		.baudrate = 115200,
 		.kseg1mask = 0x20000000,

--- a/profiledef.c
+++ b/profiledef.c
@@ -1141,7 +1141,7 @@ struct bcm2_profile bcm2_profiles[] = {
 		.kseg1mask = 0x20000000,
 		.cfg_flags = BCM2_CFG_ENC_AES256_ECB | BCM2_CFG_PAD_ZEROBLK |
 			BCM2_CFG_FMT_GWS_PAD_OPTIONAL,
-		.cfg_md5key = "544d4d5f544337323130000000000000",
+		.cfg_md5key = "544d4d5f544337323030000000000000",
 		.cfg_keyfun = &keyfun_tc7200,
 		.cfg_defkeys = {
 			"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",


### PR DESCRIPTION
`bcm2cfg` fails to parse some groups (firewall, tmmwifi & msc) but otherwise it seem to be working :) `bcm2dump` recognizes the model, I've successfully dumped `linux`, `image1`, `linuxkfs` & `linuxapps` images and extracted them with `ProgramStore`:
```
linux.bin LNXEF.01.36-kernel-20171205.bin
image1.bin TC7210-EF.01.36-171129-F-5FF.bin
linuxkfs.bin LNXEF.01.36-kernel-20171205.bin
linuxapps.bin LNXEF.01.36-apps-20171205.bin
```
Also dumped `dynnv.bin` and `bcm2cfg` parses it. Here are the logs: [tc7210_bcm2utils_logs.txt](https://github.com/jclehner/bcm2-utils/files/8011277/tc7210_bcm2utils_logs.txt)
