### PR TITLE
Add CM500 profile

### DIFF
--- a/profile.h
+++ b/profile.h
@@ -102,8 +102,8 @@ enum bcm2_arch
 	BCM2_338221 = 0x338221,
 	BCM2_3383 = 0x3383,
 	BCM2_3384 = 0x3384,
+	BCM2_33843 = 0x33843,
 	BCM2_3390 = 0x3390,
-	BCM2_3843 = 0x3843,
 };
 
 struct bcm2_partition {

--- a/profile.h
+++ b/profile.h
@@ -103,6 +103,7 @@ enum bcm2_arch
 	BCM2_3383 = 0x3383,
 	BCM2_3384 = 0x3384,
 	BCM2_3390 = 0x3390,
+	BCM2_3843 = 0x3843,
 };
 
 struct bcm2_partition {

--- a/profiledef.c
+++ b/profiledef.c
@@ -1301,6 +1301,34 @@ struct bcm2_profile bcm2_profiles[] = {
 			{ .name = "ram" },
 		},
 	},
+	{
+		.name = "cm500",
+		.pretty = "Netgear CM500",
+		.arch = BCM2_3843,
+		.pssig = 0xc312,
+		.baudrate = 115200,
+		.spaces = {
+			{ 
+				.name = "ram",
+				.min = 0x80000000,
+				.size = 128 * 1024 * 1024,
+				.parts = {
+					{ "bootloader", 0x83f80000, 0x10000 },
+				}, 
+			},
+		},
+	    .versions = {
+			{
+			    .version = "2.5.0alpha8",
+			    .intf = BCM2_INTF_BLDR,
+			    .magic = { 0x83f8cc28, "2.5.0alpha8" },
+			    .printf = 0x83f8a0f4,
+			    .sscanf = 0x83f8aac8,
+			    .rwcode = 0x86000000,
+            	.buffer = 0x87000000,
+			},
+	    },
+	},
 	// end marker
 	{ .name = "" },
 };

--- a/profiledef.c
+++ b/profiledef.c
@@ -1386,6 +1386,7 @@ struct bcm2_profile bcm2_profiles[] = {
 		.pretty = "Netgear CM500",
 		.arch = BCM2_33843,
 		.pssig = 0xc312,
+        .blsig = 0x3384,
 		.baudrate = 115200,
 		.spaces = {
 			{ 
@@ -1396,6 +1397,17 @@ struct bcm2_profile bcm2_profiles[] = {
 					{ "bootloader", 0x83f80000, 0x10000 },
 				}, 
 			},
+            {
+                .name = "flash",
+                .size = 8 * 1024 * 1024,
+                .parts = {
+                    { "bootloader", 0x00000,  0x10000  },
+                    { "permnv",     0x10000,  0x20000  },
+                    { "image1",     0x30000,  0x3d0000 },
+                    { "image2",     0x400000, 0x3c0000 },
+                    { "dynnv",      0x7c0000, 0x40000  },
+                },
+            },
 		},
 	    .versions = {
 			{

--- a/profiledef.c
+++ b/profiledef.c
@@ -1304,7 +1304,7 @@ struct bcm2_profile bcm2_profiles[] = {
 	{
 		.name = "cm500",
 		.pretty = "Netgear CM500",
-		.arch = BCM2_3843,
+		.arch = BCM2_33843,
 		.pssig = 0xc312,
 		.baudrate = 115200,
 		.spaces = {


### PR DESCRIPTION
Hi, I have tested this on my CM500 modem, and am able to dump ram in with patched dump. 

I think this is ready to be merged, but I will continue hacking on this profile. 

My main hurdle right now is the bootloader on the CM500 is missing the 'p' command, so bcm2-utils cannot read the memory map. 

Any ideas on how to move forward would be great! I have identified SpiFlashRead and SpiFlashWrite, but am unable to use them so far. 