### PR TITLE
cm500: Allow dumping flash over UART

### DIFF
--- a/profiledef.c
+++ b/profiledef.c
@@ -1418,6 +1418,12 @@ struct bcm2_profile bcm2_profiles[] = {
 			    .sscanf = 0x83f8aac8,
 			    .rwcode = 0x86000000,
             	.buffer = 0x87000000,
+                .spaces = {
+					{
+						.name = "flash",
+						.read = { 0x83f8128c, BCM2_READ_FUNC_OBL },
+					}
+				},
 			},
 	    },
 	},


### PR DESCRIPTION
I forgot that what was holding me back from adding flash dump for cm500, was that I didn't know the flash partition layout, but now that's added, I was able to add SpiFlashWrite. Tested successfully dumping image1. 